### PR TITLE
fromPojo - internalize traversePojoTree

### DIFF
--- a/src/DirectedGraph/AbstractDirectedGraph/AbstractDirectedGraph.ts
+++ b/src/DirectedGraph/AbstractDirectedGraph/AbstractDirectedGraph.ts
@@ -556,7 +556,7 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
     return subgraph as unknown as ITree<T>;
   }
 
-  private static traverseAndExtractChildren = <T>(
+  private static fromPojoTraverseAndExtractChildren = <T>(
     treeParentId: string,
     jsonParentId: string,
     dTree: ITree<T>,
@@ -569,7 +569,7 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
       if (nodePojo.nodeType === AbstractDirectedGraph.SubGraphNodeTypeName) {
         const subtree = dTree.createSubGraphAt(treeParentId);
         subtree.replaceNodeContent(subtree.rootNodeId, transformer(nodePojo));
-        AbstractDirectedGraph.traverseAndExtractChildren(
+        AbstractDirectedGraph.fromPojoTraverseAndExtractChildren(
           subtree.rootNodeId,
           nodeId,
           subtree as ITree<T>,
@@ -578,7 +578,7 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
         );
       } else {
         const childId = dTree.appendChildNodeWithContent(treeParentId, transformer(nodePojo));
-        AbstractDirectedGraph.traverseAndExtractChildren(
+        AbstractDirectedGraph.fromPojoTraverseAndExtractChildren(
           childId,
           nodeId,
           dTree,
@@ -607,7 +607,7 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
     // dTree._replaceNodeContent(dTree._rootNodeId, transform(rootNodePojo));
     delete pojoObject[rootNodeId];
 
-    AbstractDirectedGraph.traverseAndExtractChildren(
+    AbstractDirectedGraph.fromPojoTraverseAndExtractChildren(
       dTree.rootNodeId, // rootNodeId -
       // rootNodeId,
       // dTree.rootNodeId === rootNodeId ? dTree.rootNodeId : rootNodeId,

--- a/src/DirectedGraph/AbstractDirectedGraph/AbstractDirectedGraph.ts
+++ b/src/DirectedGraph/AbstractDirectedGraph/AbstractDirectedGraph.ts
@@ -62,8 +62,7 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
     parentNodeId: string,
     nodeContent: TGenericNodeContent<T>
   ): string {
-    const nodeId = this._appendChildNodeWithContent(parentNodeId, nodeContent);
-    return nodeId;
+    return this._appendChildNodeWithContent(parentNodeId, nodeContent);
   }
 
   protected _appendChildNodeWithContent(
@@ -202,22 +201,9 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
     return Object.keys(this._nodeDictionary).length;
   }
 
-  public getContentItemsWithIds(
-    nodeIds: string[]
-  ): { nodeId: string; nodeContent: ITree<T> | T | null }[] {
-    const contents = nodeIds.map((nodeId) => {
-      return {
-        nodeId,
-        nodeContent: this.getChildContent(nodeId),
-      };
-    });
-
-    return contents;
-  }
-
-  public getContentItems(nodeIds: string[]): (ITree<T> | T | null)[] {
-    return this._getContentItems(nodeIds);
-  }
+  // private getContentItems(nodeIds: string[]): (ITree<T> | T | null)[] {
+  //   return this._getContentItems(nodeIds);
+  // }
 
   private _getContentItems(nodeIds: string[]): (ITree<T> | T | null)[] {
     return nodeIds.map((childNodeId) => {
@@ -249,10 +235,6 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
         descendantContent.push(
           ...nodeContentAsAbstract.getTreeContentAt(nodeContentAsAbstract.rootNodeId)
         );
-        // @ts-ignore - hack for BranchNode (LogicalExpression2)
-      } else if (nodeContent?.nodeContent !== undefined) {
-        // @ts-ignore - hack for BranchNode (LogicalExpression2)
-        descendantContent.push(nodeContent.nodeContent);
       } else {
         descendantContent.push(nodeContent);
       }
@@ -279,10 +261,6 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
     // @ts-ignore - function not constructable
     // can we rethink this.  Is there a better way?
     return new this.constructor(rootNodeId) as typeof this;
-  }
-
-  getNodeAt(nodeId: string): TGenericNodeType<T> | undefined {
-    return this._nodeDictionary[nodeId];
   }
 
   public getParentNodeId(nodeId: string): string {
@@ -676,18 +654,6 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
         nodeContent: nodeContent.getChildContent(nodeContent.rootNodeId),
         parentId: parentNodeId,
       };
-      // @ts-ignore - nodeContent not a property, BranchNode hack
-    } else if (nodeContent.nodeContent !== undefined) {
-      workingPojoDocument[currentNodeId] = {
-        parentId: parentNodeId,
-        // @ts-ignore - nodeContent not a property, BranchNode hack
-        nodeContent: nodeContent.nodeContent as unknown as T,
-      };
-
-      const children = this._getChildrenNodeIds(currentNodeId);
-      children.forEach((childId) => {
-        this._toPojo(childId, currentNodeId, transformTtoPojo, workingPojoDocument);
-      });
     } else {
       workingPojoDocument[currentNodeId] = {
         parentId: parentNodeId,

--- a/src/DirectedGraph/AbstractDirectedGraph/AbstractDirectedGraph.ts
+++ b/src/DirectedGraph/AbstractDirectedGraph/AbstractDirectedGraph.ts
@@ -58,6 +58,14 @@ abstract class AbstractDirectedGraph<T> implements ITree<T> {
     return nodeId;
   }
 
+  public fromPojoAppendChildNodeWithContent(
+    parentNodeId: string,
+    nodeContent: TGenericNodeContent<T>
+  ): string {
+    const nodeId = this._appendChildNodeWithContent(parentNodeId, nodeContent);
+    return nodeId;
+  }
+
   protected _appendChildNodeWithContent(
     parentNodeId: string,
     nodeContent: TGenericNodeContent<T>

--- a/src/DirectedGraph/AbstractExpressionTree/AbstractExpressionTree.test.ts
+++ b/src/DirectedGraph/AbstractExpressionTree/AbstractExpressionTree.test.ts
@@ -268,5 +268,17 @@ describe("AbstractExpressionTree", () => {
       expect(dTree.countTotalNodes()).toEqual(10);
       expect(subtree.countTotalNodes()).toEqual(4);
     });
+    it("Should validate/throw error if pojo contains tree that is invalid", () => {
+      const pojo = makePojo3Children9Grandchildren();
+      // @ts-ignore - can only delete optional
+      delete pojo["child_0_0"];
+      // @ts-ignore - can only delete optional
+      delete pojo["child_0_1"];
+
+      const willThrow = () => {
+        ClassTestAbstractExpressionTree.fromPojo(pojo);
+      };
+      expect(willThrow).toThrow(Error);
+    });
   });
 });

--- a/src/DirectedGraph/AbstractExpressionTree/AbstractExpressionTree.test.ts
+++ b/src/DirectedGraph/AbstractExpressionTree/AbstractExpressionTree.test.ts
@@ -4,24 +4,15 @@ import {
   makePojo3Children9Grandchildren,
   makePojo3Children,
   makePojo2Children1subtree9leaves,
+  SortPredicateTest,
 } from "./test-utilities";
-
-// import {
-//   WidgetSort,
-//   make3Children9GrandchildrenTreeAbstract,
-//   make3ChildrenSubgraph2Children,
-//   filterPojoContent,
-//   WidgetType,
-// } from "../test-helpers/test.utilities";
-
-type operatorTypes = "==" | "!=" | "<" | ">";
-
-type TJunction = "||" | "&&";
-type TOperand = {
-  subjectId: string;
-  operator: operatorTypes;
-  value: any;
-};
+import type {
+  TJunction,
+  TOperand,
+  TOperandOperators,
+  TPredicateNodeTypes,
+  TPredicateTypes,
+} from "./types";
 
 class ClassTestAbstractExpressionTree<T> extends AbstractExpressionTree<TOperand, TJunction> {}
 describe("AbstractExpressionTree", () => {
@@ -34,17 +25,17 @@ describe("AbstractExpressionTree", () => {
     it("Should split leaf into branch.", () => {
       const rootPredicate = {
         subjectId: "customers.root",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "root",
       };
       const childPredicate0 = {
         subjectId: "customers.child0",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child0",
       };
       const childPredicate1 = {
         subjectId: "customers.child1",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child1",
       };
       const dTree = new ClassTestAbstractExpressionTree();
@@ -61,17 +52,17 @@ describe("AbstractExpressionTree", () => {
     it("(appendContentWithOr) should have appendChildWithAnd, appendChildWithOr,", () => {
       const rootPredicate = {
         subjectId: "customers.root",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "root",
       };
       const childPredicate0 = {
         subjectId: "customers.child0",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child0",
       };
       const childPredicate1 = {
         subjectId: "customers.child1",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child1",
       };
 
@@ -96,17 +87,17 @@ describe("AbstractExpressionTree", () => {
     it("(appendContentWithAnd)should have appendChildWithAnd, appendChildWithOr,", () => {
       const rootPredicate = {
         subjectId: "customers.root",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "root",
       };
       const childPredicate0 = {
         subjectId: "customers.child0",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child0",
       };
       const childPredicate1 = {
         subjectId: "customers.child1",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child1",
       };
 
@@ -132,17 +123,17 @@ describe("AbstractExpressionTree", () => {
     it("(appendContentWith(And|Or))should have appendChildWithAnd, appendChildWithOr,", () => {
       const rootPredicate = {
         subjectId: "customers.root",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "root",
       };
       const childPredicate0 = {
         subjectId: "customers.child0",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child0",
       };
       const childPredicate1 = {
         subjectId: "customers.child1",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child1",
       };
 
@@ -168,37 +159,37 @@ describe("AbstractExpressionTree", () => {
     it("(appendContentWith(And|Or))should have appendChildWithAnd, appendChildWithOr,", () => {
       const rootPredicate = {
         subjectId: "customers.root",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "root",
       };
       const childPredicate_0 = {
         subjectId: "customers.child0",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child0",
       };
       const childPredicate_1 = {
         subjectId: "customers.child1",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child1",
       };
       const childPredicate_1_0 = {
         subjectId: "customers.child1_0",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child1_0",
       };
       const childPredicate_1_1 = {
         subjectId: "customers.child1_1",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child1_1",
       };
       const childPredicate_1_2 = {
         subjectId: "customers.child1_2",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child1_2",
       };
       const childPredicate_2 = {
         subjectId: "customers.child2",
-        operator: "==" as operatorTypes,
+        operator: "$eq" as TOperandOperators,
         value: "child2",
       };
 
@@ -228,9 +219,8 @@ describe("AbstractExpressionTree", () => {
     });
     it("Should support subtrees.", () => {
       const pojo = makePojo2Children1subtree9leaves();
-
+      const { content: OO } = makePojo2Children1subtree9leaves;
       const dTree = ClassTestAbstractExpressionTree.fromPojo(pojo);
-      const x = dTree.countTotalNodes();
       const childrenIds = dTree.getChildrenNodeIds(dTree.rootNodeId);
       expect(dTree.getChildContent(childrenIds[0])).toStrictEqual({ operator: "$or" });
 
@@ -238,6 +228,42 @@ describe("AbstractExpressionTree", () => {
       const subtree = dTree.getChildContent(
         subtreeIds[0]
       ) as unknown as ClassTestAbstractExpressionTree<TJunction | TOperand>;
+
+      const x = (dTree.getTreeContentAt(dTree.rootNodeId) as TPredicateTypes[]).sort(
+        SortPredicateTest
+      );
+      expect(
+        (dTree.getTreeContentAt(dTree.rootNodeId) as TPredicateTypes[]).sort(SortPredicateTest)
+      ).toStrictEqual(
+        (
+          [
+            { operator: "$and" },
+            { operator: "$or" },
+            { operator: "$or" },
+            { operator: "$or" },
+            OO["child_0_0"],
+            OO["child_0_1"],
+            OO["child_0_2"],
+            OO["child_2_0"],
+            OO["child_2_1"],
+            OO["child_2_2"],
+          ] as TPredicateTypes[]
+        ).sort(SortPredicateTest)
+      );
+      expect(
+        (subtree.getTreeContentAt(subtree.rootNodeId) as TPredicateTypes[]).sort(
+          SortPredicateTest
+        )
+      ).toStrictEqual(
+        (
+          [
+            { operator: "$or" },
+            OO["child_1_0"],
+            OO["child_1_1"],
+            OO["child_1_2"],
+          ] as TPredicateTypes[]
+        ).sort(SortPredicateTest)
+      );
 
       expect(dTree.countTotalNodes()).toEqual(10);
       expect(subtree.countTotalNodes()).toEqual(4);

--- a/src/DirectedGraph/AbstractExpressionTree/AbstractExpressionTree.ts
+++ b/src/DirectedGraph/AbstractExpressionTree/AbstractExpressionTree.ts
@@ -101,7 +101,20 @@ export class AbstractExpressionTree<OPERAND, JUNCTION> extends AbstractDirectedG
       undefined,
       AbstractExpressionTree
     );
-
+    AbstractExpressionTree.validateTree(tree);
     return tree;
+  }
+
+  // *tmc* I don't think generics are necessary or even useful?
+  private static validateTree<T>(tree: ITree<T>) {
+    const allNodeIds = tree.getTreeNodeIdsAt(tree.rootNodeId);
+    allNodeIds.forEach((nodeId) => {
+      if (tree.isBranch(nodeId)) {
+        const childrenIds = tree.getChildrenNodeIds(nodeId);
+        if (childrenIds.length < 2) {
+          throw new Error("REPLACE - tree fails no-single-child rule.");
+        }
+      }
+    });
   }
 }

--- a/src/DirectedGraph/AbstractExpressionTree/AbstractExpressionTree.ts
+++ b/src/DirectedGraph/AbstractExpressionTree/AbstractExpressionTree.ts
@@ -2,14 +2,13 @@ import { AbstractDirectedGraph } from "../AbstractDirectedGraph";
 import { ITree } from "../ITree";
 import { TGenericNodeContent, TNodePojo, TTreePojo } from "../types";
 
-const junctionOperators = ["&&", "||", "$or", "$and"];
-
 interface IAppendChildNodeIds {
   newNodeId: string;
   originalContentNodeId?: string; // ONLY set if isNewBranch is true, represents where the content went
   junctionNodeId: string; // this will ALWAYS be the nodeId provided to append*(nodeId)
   isNewBranch: boolean;
 }
+
 export class AbstractExpressionTree<OPERAND, JUNCTION> extends AbstractDirectedGraph<
   OPERAND | JUNCTION
 > {
@@ -82,10 +81,11 @@ export class AbstractExpressionTree<OPERAND, JUNCTION> extends AbstractDirectedG
     // at this time, only *fromPojo is calling this function.
     // need to move traverse tree logic from utilities to
     // to static methods?
-    return this.appendChildNodeWithContentFromPojo(parentNodeId, nodeContent);
+    // return this.appendContentWithAnd(parentNodeId, nodeContent);
+    return this.fromPojoAppendChildNodeWithContent(parentNodeId, nodeContent);
   }
 
-  public appendChildNodeWithContentFromPojo(
+  public fromPojoAppendChildNodeWithContent(
     parentNodeId: string,
     nodeContent: TGenericNodeContent<OPERAND | JUNCTION>
   ): string {
@@ -93,21 +93,6 @@ export class AbstractExpressionTree<OPERAND, JUNCTION> extends AbstractDirectedG
       return super.appendChildNodeWithContent(parentNodeId, nodeContent);
     }
     return super.appendChildNodeWithContent(parentNodeId, nodeContent);
-
-    // const originalContent = this.getChildContent(parentNodeId);
-    // const originalContentId = super.appendChildNodeWithContent(parentNodeId, originalContent);
-
-    // let newNodeId;
-    // if (this.isBranchNodeContent(nodeContent)) {
-    //   this.replaceNodeContent(parentNodeId, nodeContent);
-    //   newNodeId = super.appendChildNodeWithContent(parentNodeId, null);
-    // } else {
-    //   this.replaceNodeContent(parentNodeId, null);
-    //   newNodeId = super.appendChildNodeWithContent(parentNodeId, nodeContent);
-    // }
-    // this.replaceNodeContent(parentNodeId, null);
-    // const newNodeId = super.appendChildNodeWithContent(parentNodeId, nodeContent);
-    // return newNodeId;
   }
 
   static fromPojo<T>(srcPojoTree: TTreePojo<T>): ITree<T> {

--- a/src/DirectedGraph/AbstractExpressionTree/test-utilities.ts
+++ b/src/DirectedGraph/AbstractExpressionTree/test-utilities.ts
@@ -1,3 +1,15 @@
+import type {
+  TJunction,
+  TOperand,
+  TOperandOperators,
+  TPredicateNodeTypes,
+  TPredicateTypes,
+} from "./types";
+import { ITree } from "../ITree";
+
+// type PredicateTypes = TOperand | TJunction;
+// type PredicateNodeTypes = TOperand | TJunction;
+
 const makePojo3Children9Grandchildren = () => {
   return {
     root: {
@@ -97,106 +109,216 @@ const makePojo3Children9Grandchildren = () => {
   };
 };
 
+const pojo2Children1subtree9leaves_content: { [nodeId: string]: TPredicateTypes } = {};
+pojo2Children1subtree9leaves_content["root"] = { operator: "$and" };
+pojo2Children1subtree9leaves_content["child_0"] = { operator: "$or" };
+pojo2Children1subtree9leaves_content["child_1"] = { operator: "$or" };
+pojo2Children1subtree9leaves_content["child_2"] = { operator: "$or" };
+pojo2Children1subtree9leaves_content["child_0_0"] = {
+  operator: "$eq",
+  subjectId: "customer.child_0_0",
+  value: "child_0_0",
+};
+pojo2Children1subtree9leaves_content["child_0_1"] = {
+  operator: "$eq",
+  subjectId: "customer.child_0_1",
+  value: "child_0_1",
+};
+pojo2Children1subtree9leaves_content["child_0_2"] = {
+  operator: "$eq",
+  subjectId: "customer.child_0_2",
+  value: "child_0_2",
+};
+pojo2Children1subtree9leaves_content["child_1_0"] = {
+  operator: "$eq",
+  subjectId: "customer.child_1_0",
+  value: "child_1_0",
+};
+pojo2Children1subtree9leaves_content["child_1_1"] = {
+  operator: "$eq",
+  subjectId: "customer.child_1_1",
+  value: "child_1_1",
+};
+pojo2Children1subtree9leaves_content["child_1_2"] = {
+  operator: "$eq",
+  subjectId: "customer.child_1_2",
+  value: "child_1_2",
+};
+pojo2Children1subtree9leaves_content["child_2_0"] = {
+  operator: "$eq",
+  subjectId: "customer.child_2_0",
+  value: "child_2_0",
+};
+pojo2Children1subtree9leaves_content["child_2_1"] = {
+  operator: "$eq",
+  subjectId: "customer.child_2_1",
+  value: "child_2_1",
+};
+pojo2Children1subtree9leaves_content["child_2_2"] = {
+  operator: "$eq",
+  subjectId: "customer.child_2_2",
+  value: "child_2_2",
+};
+
+// --------
+const makePojo2Children1subtree9leaves_content = {
+  root: {
+    parentId: "root",
+    nodeContent: { operator: "$and" },
+  },
+  child_0: {
+    parentId: "root",
+    nodeContent: {
+      operator: "$or",
+    },
+  },
+  child_1: {
+    parentId: "root",
+    nodeType: "subtree",
+    nodeContent: {
+      operator: "$or",
+    },
+  },
+  child_2: {
+    parentId: "root",
+    nodeContent: {
+      operator: "$or",
+    },
+  },
+  child_0_0: {
+    parentId: "child_0",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_0_0",
+      value: "child_0_0",
+    },
+  },
+  child_0_1: {
+    parentId: "child_0",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_0_1",
+      value: "child_0_1",
+    },
+  },
+  child_0_2: {
+    parentId: "child_0",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_0_2",
+      value: "child_0_2",
+    },
+  },
+  child_1_0: {
+    parentId: "child_1",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_1_0",
+      value: "child_1_0",
+    },
+  },
+  child_1_1: {
+    parentId: "child_1",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_1_1",
+      value: "child_1_1",
+    },
+  },
+  child_1_2: {
+    parentId: "child_1",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_1_2",
+      value: "child_1_2",
+    },
+  },
+  child_2_0: {
+    parentId: "child_2",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_2_0",
+      value: "child_2_0",
+    },
+  },
+  child_2_1: {
+    parentId: "child_2",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_2_1",
+      value: "child_2_1",
+    },
+  },
+  child_2_2: {
+    parentId: "child_2",
+    nodeContent: {
+      operator: "$eq",
+      subjectId: "customer.child_2_2",
+      value: "child_2_2",
+    },
+  },
+};
+
 const makePojo2Children1subtree9leaves = () => {
+  const content = pojo2Children1subtree9leaves_content;
   return {
     root: {
       parentId: "root",
-      nodeContent: { operator: "$and" },
+      nodeContent: content["root"],
     },
     child_0: {
       parentId: "root",
-      nodeContent: {
-        operator: "$or",
-      },
+      nodeContent: content["child_0"],
     },
     child_1: {
       parentId: "root",
       nodeType: "subtree",
-      nodeContent: {
-        operator: "$or",
-      },
+      nodeContent: content["child_1"],
     },
     child_2: {
       parentId: "root",
-      nodeContent: {
-        operator: "$or",
-      },
+      nodeContent: content["child_2"],
     },
     child_0_0: {
       parentId: "child_0",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_0_0",
-        value: "child_0_0",
-      },
+      nodeContent: content["child_0_0"],
     },
     child_0_1: {
       parentId: "child_0",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_0_1",
-        value: "child_0_1",
-      },
+      nodeContent: content["child_0_1"],
     },
     child_0_2: {
       parentId: "child_0",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_0_2",
-        value: "child_0_2",
-      },
+      nodeContent: content["child_0_2"],
     },
     child_1_0: {
       parentId: "child_1",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_1_0",
-        value: "child_1_0",
-      },
+      nodeContent: content["child_1_0"],
     },
     child_1_1: {
       parentId: "child_1",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_1_1",
-        value: "child_1_1",
-      },
+      nodeContent: content["child_1_1"],
     },
     child_1_2: {
       parentId: "child_1",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_1_2",
-        value: "child_1_2",
-      },
+      nodeContent: content["child_1_2"],
     },
     child_2_0: {
       parentId: "child_2",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_2_0",
-        value: "child_2_0",
-      },
+      nodeContent: content["child_2_0"],
     },
     child_2_1: {
       parentId: "child_2",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_2_1",
-        value: "child_2_1",
-      },
+      nodeContent: content["child_2_1"],
     },
     child_2_2: {
       parentId: "child_2",
-      nodeContent: {
-        operator: "$eq",
-        subjectId: "customer.child_2_2",
-        value: "child_2_2",
-      },
+      nodeContent: content["child_2_2"],
     },
   };
 };
 
+makePojo2Children1subtree9leaves.content = pojo2Children1subtree9leaves_content;
 const makePojo3Children = () => {
   return {
     root: {
@@ -229,8 +351,55 @@ const makePojo3Children = () => {
     },
   };
 };
+
+const isBranchPredicate = (p: TPredicateTypes) => {
+  return p.operator === "$or" || p.operator === "$and";
+};
+
+const isLeafPredicate = (p: TPredicateTypes) => {
+  return !isBranchPredicate(p);
+};
+
+const SortPredicateTest = (
+  predicate1: TPredicateNodeTypes | null,
+  predicate2: TPredicateNodeTypes | null
+) => {
+  const p1 = predicate1 as TPredicateTypes;
+  const p2 = predicate2 as TPredicateTypes;
+  if (isBranchPredicate(p1) && isBranchPredicate(p2)) {
+    if (p1.operator > p2.operator) {
+      return 1;
+    }
+    if (p1.operator < p2.operator) {
+      return -1;
+    }
+    return 0;
+  }
+  if (isBranchPredicate(p1) && !isBranchPredicate(p2)) {
+    return -1;
+  }
+  if (!isBranchPredicate(p1) && isBranchPredicate(p2)) {
+    return 1;
+  }
+
+  if (isLeafPredicate(p1) && isLeafPredicate(p2)) {
+    const { value: v1 } = p1 as unknown as TOperand;
+    const { value: v2 } = p2 as unknown as TOperand;
+    if ((v1 as string) > (v2 as string)) {
+      return 1;
+    }
+    if ((v1 as string) < (v2 as string)) {
+      return -1;
+    }
+    return 0;
+  }
+
+  return -1;
+};
+
 export {
   makePojo3Children9Grandchildren,
   makePojo3Children,
   makePojo2Children1subtree9leaves,
+  SortPredicateTest,
 };

--- a/src/DirectedGraph/AbstractExpressionTree/types.ts
+++ b/src/DirectedGraph/AbstractExpressionTree/types.ts
@@ -1,0 +1,17 @@
+type TOperandOperators = "$eq" | "$lte" | "$le" | "$gt" | "$gte";
+type TJunctionOperators = "$or" | "$and";
+import type { ITree } from "../ITree";
+
+type TJunction = {
+  operator: TJunctionOperators;
+};
+type TOperand = {
+  subjectId: string;
+  operator: TOperandOperators;
+  value: any;
+};
+// type TPredicateTypes = PredicateTypes | ITree<PredicateTypes>;
+type TPredicateTypes = TJunction | TOperand;
+type TPredicateNodeTypes = TPredicateTypes | ITree<TPredicateTypes>; // does null belong here?
+
+export type { TJunction, TOperand, TOperandOperators, TPredicateNodeTypes, TPredicateTypes };

--- a/src/DirectedGraph/ITree.ts
+++ b/src/DirectedGraph/ITree.ts
@@ -16,10 +16,11 @@ interface ITreeVisitor<T> {
 
 interface ITree<T> {
   rootNodeId: string;
+
   appendChildNodeWithContent: (
     treeParentId: string,
     nodeContent: TGenericNodeContent<T>
-  ) => string;
+  ) => string; // why use arrow notation?
   cloneAt(nodeId: string): ITree<T>;
 
   countGreatestDepthOf(nodeId?: string): number;
@@ -28,10 +29,13 @@ interface ITree<T> {
   countTotalNodes(nodeId?: string): number;
 
   createSubGraphAt(nodeId: string): ITree<T>;
-
+  fromPojoAppendChildNodeWithContent(
+    treeParentId: string,
+    nodeContent: TGenericNodeContent<T>
+  ): string;
   // maybe null
   getChildContent(nodeId: string): TGenericNodeContent<T>;
-  getNodeAt(nodeId: string): TGenericNodeType<T> | undefined;
+  // getNodeAt(nodeId: string): TGenericNodeType<T> | undefined;
   getChildrenContent(nodeId: string): TGenericNodeContent<T>[];
   getChildrenNodeIds(parentNodeId: string): string[];
   getDescendantContent(nodeId: string): TGenericNodeContent<T>[];

--- a/src/TreeObfuscator/TreeObfuscator.test.ts
+++ b/src/TreeObfuscator/TreeObfuscator.test.ts
@@ -213,7 +213,7 @@ describe("TreeObfuscator", () => {
   });
 
   describe("SubTree POJO to/from", () => {
-    it("Blue skies", () => {
+    it.only("Blue skies", () => {
       const originalGraph = new TestAbstractDirectedGraph(undefined);
       const obfuscatedGraph = new TreeObfuscator(originalGraph);
       const { dTreeIds, dTree, subgraph } =

--- a/src/TreeObfuscator/TreeObfuscator.test.ts
+++ b/src/TreeObfuscator/TreeObfuscator.test.ts
@@ -213,7 +213,7 @@ describe("TreeObfuscator", () => {
   });
 
   describe("SubTree POJO to/from", () => {
-    it.only("Blue skies", () => {
+    it("Blue skies", () => {
       const originalGraph = new TestAbstractDirectedGraph(undefined);
       const obfuscatedGraph = new TreeObfuscator(originalGraph);
       const { dTreeIds, dTree, subgraph } =

--- a/src/TreeObfuscator/TreeObfuscator.ts
+++ b/src/TreeObfuscator/TreeObfuscator.ts
@@ -27,6 +27,13 @@ class TreeObfuscator<T> implements ITree<T> {
     return this._keyMap.putValue(nodeId);
   }
 
+  fromPojoAppendChildNodeWithContent(
+    treeParentKey: string,
+    nodeContent: TGenericNodeContent<T>
+  ): string {
+    return this.appendChildNodeWithContent(treeParentKey, nodeContent);
+  }
+
   cloneAt(nodeKey: string): ITree<T> {
     const nodeId = this.getNodeIdOrThrow(nodeKey);
     return this._internalTree.cloneAt(nodeId);
@@ -79,10 +86,10 @@ class TreeObfuscator<T> implements ITree<T> {
     return nodeId;
   }
 
-  public getNodeAt(nodeKey: string): TGenericNodeType<T> | undefined {
-    const nodeId = this.getNodeId(nodeKey);
-    return this._internalTree.getNodeAt(nodeId);
-  }
+  // public getNodeAt(nodeKey: string): TGenericNodeType<T> | undefined {
+  //   const nodeId = this.getNodeId(nodeKey);
+  //   return this._internalTree.getNodeAt(nodeId);
+  // }
 
   getChildContent(nodeKey: string): TGenericNodeContent<T> {
     const nodeId = this.getNodeId(nodeKey);


### PR DESCRIPTION
- added support for AbstractExpressTree.validate(tree), currently catches single-child, does no other validation.
- internalized `fromPojoTraverseAndExtractChildren` it is now part of the classes and not treeutilities
- created ticket on flesh-out to do the reset of the validation


Closes #5, #2